### PR TITLE
Base64encodepayload

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,12 +344,19 @@ Other result values:
 
 Header: ```vernemq-hook: on_offline_message```
 
+Note, in the example below the payload is not base64 encoded which is not the
+default.
+
 Webhook example payload:
 
 ```json
 {
     "client_id": "clientid",
-    "mountpoint": ""
+    "mountpoint": "",
+    "qos": "1",
+    "topic": "sometopic",
+    "payload": "payload",
+    "retain": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Webhook example payload:
 {
     "peer_addr": "127.0.0.1",
     "peer_port": 8888,
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "username": "username",
     "password": "password",
     "mountpoint": "",
@@ -95,7 +95,7 @@ Example response:
     "result": "ok",
     "modifiers": {
         "mountpoint": "newmountpoint"
-        "subscriber_id": "subscriber_id",
+        "client_id": "clientid",
         "reg_view": "reg_view",
         "clean_session": false,
         "max_message_size": 65535,
@@ -126,7 +126,7 @@ Webhook example payload:
 
 ```json
 {
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": "",
     "username": "username",
     "topics":
@@ -170,7 +170,7 @@ Webhook example payload:
 ```json
 {
     "username": "username",
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": "",
     "qos": 1,
     "topic": "a/b",
@@ -217,7 +217,7 @@ Webhook example payload:
     "peer_port": 8888,
     "username": "username",
     "mountpoint": "",
-    "subscriber_id": "subscriberid"
+    "client_id": "clientid"
 }
 ```
 
@@ -235,7 +235,7 @@ Webhook example payload:
 ```json
 {
     "username": "username",
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": "",
     "qos": 1,
     "topic": "a/b",
@@ -254,7 +254,7 @@ Webhook example payload:
 
 ```json
 {
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": "",
     "username": "username",
     "topics":
@@ -276,7 +276,7 @@ Webhook example payload:
 ```json
 {
     "username": "username",
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": "",
     "topics":
         ["a/b", "c/d"]
@@ -315,7 +315,7 @@ Webhook example payload:
 ```json
 {
     "username": "username",
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": "",
     "topic": "a/b",
     "payload": "hello"
@@ -348,7 +348,7 @@ Webhook example payload:
 
 ```json
 {
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": ""
 }
 ```
@@ -363,7 +363,7 @@ Webhook example payload:
 
 ```json
 {
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": ""
 }
 ```
@@ -378,7 +378,7 @@ Webhook example payload:
 
 ```json
 {
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": ""
 }
 ```
@@ -393,7 +393,7 @@ Webhook example payload:
 
 ```json
 {
-    "subscriber_id": "subscriberid",
+    "client_id": "clientid",
     "mountpoint": ""
 }
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,14 @@ Deregistering an endpoint:
     $ vmq-admin webhooks deregister hook=auth_on_register endpoint="http://localhost"
 
 The payload is by default base64 encoded, to disable this add the
-`--encodepayload=false` flag when registering the hook.
+`--base64payload=false` flag when registering the hook.
+
+## Persisting hooks across VerneMQ restarts
+
+Webhooks added with `vmq-plugin` command line tool are not persisted across
+VerneMQ restarts. To make hooks persistent they can be added to the
+`priv/vmq_webhooks.conf` file. It contains an example and is hopefully
+self-explanatory.
 
 ## Webhooks
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ For the above reasons, we recommend that in your production environment you
 deploy your endpoints on the same machines where you are deploying VerneMQ and
 configure the endpoints to be reached via `localhost`.
 
+## Changelog
+
+See [changelog.md](./changelog.md) for changes.
+
 ## Usage
 
 Building the plugin:
@@ -48,6 +52,9 @@ Registering a hook with an endpoint:
 Deregistering an endpoint:
 
     $ vmq-admin webhooks deregister hook=auth_on_register endpoint="http://localhost"
+
+The payload is by default base64 encoded, to disable this add the
+`--encodepayload=false` flag when registering the hook.
 
 ## Webhooks
 
@@ -155,6 +162,9 @@ Other result values:
 
 Header: ```vernemq-hook: auth_on_publish```
 
+Note, in the example below the payload is not base64 encoded which is not the
+default.
+
 Webhook example payload:
 
 ```json
@@ -216,6 +226,9 @@ The response of this hook should be empty as it is ignored.
 ### on_publish
 
 Header: ```vernemq-hook: on_publish```
+
+Note, in the example below the payload is not base64 encoded which is not the
+default.
 
 Webhook example payload:
 
@@ -293,6 +306,9 @@ Other result values:
 ### on_deliver
 
 Header: ```vernemq-hook: on_deliver```
+
+Note, in the example below the payload is not base64 encoded which is not the
+default.
 
 Webhook example payload:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## vmq_webhooks 0.2.0
+
+Backwards incompatible changes:
+
+ - base64 encode MQTT payloads by default.
+ - In all hooks `subscriber_id` has been renamed to `client_id` to be consistent
+   with VerneMQ and other plugins where a `subscriber_id` is defined as a
+   mountpoint and a client id.
+ - `on_offline_message` now also passes `qos`, `topic`, `payload` and `retain`
+   fields as part of the JSON message. Note, that this change **requires VerneMQ
+   0.15.2 or newer to work**.
+
+Other changes:
+
+ - Webhooks can be persisted across broker restarts by adding them to the
+   `priv/vmq_webhooks.conf` file.
+
+
+## vmq_webhooks 0.1.0
+
+Initial version.

--- a/priv/vmq_webhooks.conf
+++ b/priv/vmq_webhooks.conf
@@ -1,0 +1,12 @@
+%% VerneMQ Webhooks configuration file
+%% The file format is {hooks, VersionNumber, Hooks}
+%%
+%% Example:
+%% {hooks,1,
+%%  [
+%%   {"http://localhost", auth_on_register, [{base64_payload, false}]},
+%%   {"http://localhost", auth_on_subscribe, [{base64_payload, true}]}
+%%  ]}.
+{hooks,1,
+ [
+ ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         {hackney, "1.6.0"},
         {jsx, "2.8.0"},
 
-        {vmq_commons, {git, "git://github.com/erlio/vmq_commons.git", {branch, "master"}}}
+        {vernemq_dev, {git, "git://github.com/erlio/vernemq_dev.git", {branch, "master"}}}
        ]}.
 
 {profiles,

--- a/rebar.lock
+++ b/rebar.lock
@@ -12,9 +12,9 @@
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.2">>},1},
  {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.1">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.0">>},1},
- {<<"vmq_commons">>,
-  {git,"git://github.com/erlio/vmq_commons.git",
-       {ref,"a87b4911344e8e55631361e68a745cc3a7e02815"}},
+ {<<"vernemq_dev">>,
+  {git,"git://github.com/erlio/vernemq_dev.git",
+       {ref,"087fb0f84a2a848b71cc5e2391c4a3bac916a52f"}},
   0}]}.
 [
 {pkg_hash,[

--- a/src/vmq_webhooks_plugin.erl
+++ b/src/vmq_webhooks_plugin.erl
@@ -36,7 +36,7 @@
          on_subscribe/3,
          on_unsubscribe/3,
          on_deliver/4,
-         on_offline_message/1,
+         on_offline_message/5,
          on_client_wakeup/1,
          on_client_offline/1,
          on_client_gone/1]).
@@ -291,10 +291,14 @@ on_deliver(UserName, SubscriberId, Topic, Payload) ->
                              {topic, unword(Topic)},
                              {payload, Payload}]).
 
-on_offline_message(SubscriberId) ->
+on_offline_message(SubscriberId, QoS, Topic, Payload, IsRetain) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all(on_offline_message, [{mountpoint, MP},
-                             {client_id, ClientId}]).
+                             {client_id, ClientId},
+                             {qos, QoS},
+                             {topic, unword(Topic)},
+                             {payload, Payload},
+                             {retain, IsRetain}]).
 
 on_client_wakeup(SubscriberId) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
@@ -387,7 +391,8 @@ unword(T) ->
     iolist_to_binary(vmq_topic:unword(T)).
 
 check_modifiers(Hook, Modifiers)
-  when (Hook == auth_on_publish) or (Hook == on_deliver) ->
+  when (Hook == auth_on_publish) or (Hook == on_deliver)
+       or (Hook == on_offline_message) ->
     case lists:keyfind(topic, 1, Modifiers) of
         {topic, T} when is_binary(T) ->
             case vmq_topic:validate_topic(publish, T) of

--- a/src/vmq_webhooks_plugin.erl
+++ b/src/vmq_webhooks_plugin.erl
@@ -43,7 +43,7 @@
 
 %% API
 -export([start_link/0
-        ,register_endpoint/2
+        ,register_endpoint/3
         ,deregister_endpoint/2
         ,all_hooks/0
         ]).
@@ -71,8 +71,8 @@
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-register_endpoint(Endpoint, HookName) when is_binary(Endpoint), is_atom(HookName) ->
-    gen_server:call(?MODULE, {register_endpoint, Endpoint, HookName}).
+register_endpoint(Endpoint, HookName, Opts) when is_binary(Endpoint), is_atom(HookName) ->
+    gen_server:call(?MODULE, {register_endpoint, Endpoint, HookName, Opts}).
 
 deregister_endpoint(Endpoint, HookName) when is_binary(Endpoint), is_atom(HookName) ->
     gen_server:call(?MODULE, {deregister_endpoint, Endpoint, HookName}).
@@ -118,19 +118,20 @@ init([]) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
-handle_call({register_endpoint, Endpoint, Hook}, _From, State) ->
+
+handle_call({register_endpoint, Endpoint, Hook, Opts}, _From, State) ->
     Reply =
         case ets:lookup(?TBL, Hook) of
             [] ->
                 enable_hook(Hook),
-                ets:insert(?TBL, {Hook, [Endpoint]}),
+                ets:insert(?TBL, {Hook, [{Endpoint, Opts}]}),
                 ok;
             [{_, Endpoints}] ->
-                case lists:member(Endpoint, Endpoints) of
+                case lists:keymember(Endpoint, 1, Endpoints) of
                     false -> 
                         %% Hooks/endpoints are invoked in list order
                         %% and oldest should be invoked first.
-                        NewEndpoints = Endpoints ++ [Endpoint],
+                        NewEndpoints = Endpoints ++ [{Endpoint, Opts}],
                         ets:insert(?TBL, {Hook, NewEndpoints}),
                         ok;
                     true ->
@@ -144,16 +145,16 @@ handle_call({deregister_endpoint, Endpoint, Hook}, _From, State) ->
         case ets:lookup(?TBL, Hook) of
             [] ->
                 {error, not_found};
-            [{_, [Endpoint]}] ->
+            [{_, [{Endpoint, _}]}] ->
                 disable_hook(Hook),
                 ets:delete(?TBL, Hook),
                 ok;
             [{_, Endpoints}] ->
-                case lists:member(Endpoint, Endpoints) of
+                case lists:keymember(Endpoint, 1, Endpoints) of
                     false ->
                         {error, not_found};
                     true ->
-                        ets:insert(?TBL, {Hook, lists:delete(Endpoint, Endpoints)}),
+                        ets:insert(?TBL, {Hook, lists:keydelete(Endpoint, 1, Endpoints)}),
                         ok
                 end
         end,
@@ -198,8 +199,9 @@ handle_info(_Info, State) ->
 %% @end
 %%--------------------------------------------------------------------
 terminate(_Reason, _State) ->
-    {_Hooks, Endpoints} = lists:unzip(all_hooks()),
-    [ hackney_pool:stop_pool(E) || E <- lists:usort(lists:flatten(Endpoints)) ],
+    {_Hooks, Vals} = lists:unzip(all_hooks()),
+    {Endpoints, _Opts} = lists:unzip(Vals),
+    [ hackney_pool:stop_pool(E) || {E,_} <- lists:usort(lists:flatten(Endpoints)) ],
     ok.
 
 %%--------------------------------------------------------------------
@@ -318,7 +320,7 @@ maybe_start_pool(Endpoint) ->
 
 maybe_stop_pool(Endpoint) ->
     InUse = lists:filter(fun({_, Endpoints}) ->
-                                 lists:member(Endpoint, Endpoints)
+                                 lists:keymember(Endpoint, 1, Endpoints)
                          end, all_hooks()),
     case InUse of
         [] -> hackney_pool:stop_pool(Endpoint);
@@ -350,8 +352,8 @@ all_till_ok(HookName, Args) ->
             all_till_ok(Endpoints, HookName, Args)
     end.
 
-all_till_ok([Endpoint|Rest], HookName, Args) ->
-    case call_endpoint(Endpoint, HookName, Args) of
+all_till_ok([{Endpoint,EOpts}|Rest], HookName, Args) ->
+    case call_endpoint(Endpoint, EOpts, HookName, Args) of
         true ->
             ok;
         Modifiers when is_list(Modifiers) ->
@@ -376,8 +378,8 @@ all(HookName, Args) ->
             all(Endpoints, HookName, Args)
     end.
 
-all([Endpoint|Rest], HookName, Args) ->
-    _ = call_endpoint(Endpoint, HookName, Args),
+all([{Endpoint,EOpts}|Rest], HookName, Args) ->
+    _ = call_endpoint(Endpoint, EOpts, HookName, Args),
     all(Rest, HookName, Args);
 all([], _, _) -> next.
 
@@ -439,19 +441,19 @@ peer({Peer, Port}) when is_tuple(Peer) and is_integer(Port) ->
 subscriber_id({"", ClientId}) -> {<<>>, ClientId};
 subscriber_id({MP, ClientId}) -> {list_to_binary(MP), ClientId}.
 
-call_endpoint(Endpoint, Hook, Args) ->
+call_endpoint(Endpoint, EOpts, Hook, Args) ->
     Method = post,
     Headers = [{<<"Content-Type">>, <<"application/json">>},
                {<<"vernemq-hook">>, atom_to_binary(Hook, utf8)}],
     Opts = [{pool, Endpoint}],
     Res =
-        case hackney:request(Method, Endpoint, Headers, encode_payload(Hook, Args), Opts) of
+        case hackney:request(Method, Endpoint, Headers, encode_payload(Hook, Args, EOpts), Opts) of
             {ok, 200, _RespHeaders, CRef} ->
                 case hackney:body(CRef) of
                     {ok, Body} ->
                         case jsx:is_json(Body) of
                             true ->
-                                handle_response(Hook, jsx:decode(Body, [{labels, atom}]));
+                                handle_response(Hook, jsx:decode(Body, [{labels, atom}]), EOpts);
                             false ->
                                 {error, received_payload_not_json}
                         end;
@@ -476,53 +478,59 @@ call_endpoint(Endpoint, Hook, Args) ->
             Res
     end.
 
-handle_response(Hook, Decoded) 
+handle_response(Hook, Decoded, EOpts) 
   when Hook =:= auth_on_register; Hook =:= auth_on_publish;
        Hook =:= on_deliver ->
     case proplists:get_value(result, Decoded) of
         <<"ok">> ->
-            normalize_modifiers(Hook, proplists:get_value(modifiers, Decoded, []));
+            normalize_modifiers(Hook, proplists:get_value(modifiers, Decoded, []), EOpts);
         <<"next">> -> next;
         Result when is_list(Result) ->
             {decoded_error, proplists:get_value(error, Result, unknown_error)}
     end;
-handle_response(Hook, Decoded)
+handle_response(Hook, Decoded, EOpts)
   when Hook =:= auth_on_subscribe; Hook =:= on_unsubscribe ->
     case proplists:get_value(result, Decoded) of
         <<"ok">> ->
-            normalize_modifiers(Hook, proplists:get_value(topics, Decoded, []));
+            normalize_modifiers(Hook, proplists:get_value(topics, Decoded, []), EOpts);
         <<"next">> -> next;
         Result when is_list(Result) ->
             {decoded_error, proplists:get_value(error, Result, unknown_error)}
     end;
-handle_response(_Hook, _Decoded) ->
+handle_response(_Hook, _Decoded, _) ->
     next.
 
-normalize_modifiers(auth_on_register, Mods) ->
+normalize_modifiers(auth_on_register, Mods, _) ->
     lists:map(
       fun({mountpoint, Mountpoint}) ->
               {mountpoint, binary_to_list(Mountpoint)};
          (E) -> E
       end, Mods);
-normalize_modifiers(auth_on_subscribe, Topics) ->
+normalize_modifiers(auth_on_subscribe, Topics, _) ->
     lists:map(
       fun(PL) ->
               [proplists:get_value(topic, PL),
                proplists:get_value(qos, PL)]
       end,
       Topics);
-normalize_modifiers(auth_on_publish, Mods) ->
+normalize_modifiers(auth_on_publish, Mods, EOpts) ->
     lists:map(
       fun({mountpoint, Mountpoint}) ->
               {mountpoint, binary_to_list(Mountpoint)};
+         ({payload, Payload}) ->
+              {payload, b64decode(Payload, EOpts)};
          (E) -> E
       end, Mods);
-normalize_modifiers(on_unsubscribe, Mods) ->
-    Mods;
-normalize_modifiers(on_deliver, Mods) ->
+normalize_modifiers(on_deliver, Mods, EOpts) ->
+    lists:map(
+      fun({payload, Payload}) ->
+              {payload, b64decode(Payload, EOpts)};
+         (E) -> E
+      end, Mods);
+normalize_modifiers(on_unsubscribe, Mods, _) ->
     Mods.
 
-encode_payload(Hook, Args)
+encode_payload(Hook, Args, _Opts)
   when Hook =:= auth_on_subscribe; Hook =:= on_subscribe ->
     RemappedKeys = 
         lists:map(
@@ -539,13 +547,25 @@ encode_payload(Hook, Args)
           end,
           Args),
     jsx:encode(RemappedKeys);
-encode_payload(_, Args) ->
+encode_payload(_, Args, Opts) ->
     RemappedKeys = 
         lists:map(
           fun({addr, V}) -> {peer_addr, V};
              ({port, V}) -> {peer_port, V};
              ({client_id, V}) -> {subscriber_id, V};
+             ({payload, V}) ->
+                  {payload, b64encode(V, Opts)};
              (V) -> V
           end,
           Args),
     jsx:encode(RemappedKeys).
+
+b64encode(V, #{encode_payload := false}) ->
+    V;
+b64encode(V, _) -> 
+    base64:encode(V).
+
+b64decode(V, #{encode_payload := false}) ->
+    V;
+b64decode(V, _) -> 
+    base64:decode(V).

--- a/src/vmq_webhooks_plugin.erl
+++ b/src/vmq_webhooks_plugin.erl
@@ -542,7 +542,7 @@ encode_payload(Hook, Args, _Opts)
                                       {qos, Q}]
                              end,
                      Topics)};
-             ({client_id, V}) -> {subscriber_id, V};
+             ({client_id, V}) -> {client_id, V};
              (V) -> V
           end,
           Args),
@@ -552,7 +552,7 @@ encode_payload(_, Args, Opts) ->
         lists:map(
           fun({addr, V}) -> {peer_addr, V};
              ({port, V}) -> {peer_port, V};
-             ({client_id, V}) -> {subscriber_id, V};
+             ({client_id, V}) -> {client_id, V};
              ({payload, V}) ->
                   {payload, b64encode(V, Opts)};
              (V) -> V

--- a/src/vmq_webhooks_plugin.erl
+++ b/src/vmq_webhooks_plugin.erl
@@ -565,12 +565,12 @@ encode_payload(_, Args, Opts) ->
           Args),
     jsx:encode(RemappedKeys).
 
-b64encode(V, #{encode_payload := false}) ->
+b64encode(V, #{base64_payload := false}) ->
     V;
 b64encode(V, _) -> 
     base64:encode(V).
 
-b64decode(V, #{encode_payload := false}) ->
+b64decode(V, #{base64_payload := false}) ->
     V;
 b64decode(V, _) -> 
     base64:decode(V).

--- a/src/vmq_webhooks_sup.erl
+++ b/src/vmq_webhooks_sup.erl
@@ -20,7 +20,15 @@
 %%====================================================================
 
 start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+    case supervisor:start_link({local, ?SERVER}, ?MODULE, []) of
+        {ok, _} = Ret ->
+            spawn(fun() ->
+                          ConfDir = application:get_env(vmq_webhooks, config_dir, code:priv_dir(vmq_webhooks)),
+                          register_hooks(ConfDir)
+                  end),
+            Ret;
+        E -> E
+    end.
 
 %%====================================================================
 %% Supervisor callbacks
@@ -40,3 +48,30 @@ init([]) ->
 %%====================================================================
 %% Internal functions
 %%====================================================================
+
+
+register_hooks(ConfDir) ->
+    File = ConfDir ++ "/vmq_webhooks.conf",
+    case file:consult(File) of
+        {ok, [{hooks,1,Hooks}]} ->
+            lists:foreach(
+              fun({Endpoint, HookName, Opts}) when is_list(Endpoint),
+                                                   is_atom(HookName),
+                                                   is_list(Opts) ->
+                      register_hook(list_to_binary(Endpoint), HookName, Opts);
+                 (Unknown) ->
+                      lager:warning("Unknown webhook: ~n", [Unknown])
+              end,
+              Hooks);
+        {error, Reason} ->
+            lager:error("Failed to load ~p, reason: ~p", [File, Reason])
+    end.
+
+register_hook(Endpoint, HookName, Opts) ->
+    case vmq_webhooks_plugin:register_endpoint(Endpoint, HookName, maps:from_list(Opts)) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            lager:error("Failed to register webhook: ~p ~p ~p, reason: ~p",
+                        [Endpoint, HookName, Opts, Reason])
+    end.

--- a/test/vmq_webhooks_SUITE.erl
+++ b/test/vmq_webhooks_SUITE.erl
@@ -76,44 +76,44 @@ stop_endpoint() ->
 auth_on_register_test(_) ->
     register_hook(auth_on_register, ?ENDPOINT),
     ok = vmq_plugin:all_till_ok(auth_on_register,
-                      [?PEER, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, ?USERNAME, ?PASSWORD, true]),
+                      [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     {error, [error]} = vmq_plugin:all_till_ok(auth_on_register,
-                      [?PEER, {?MOUNTPOINT, ?NOT_ALLOWED_SUBSCRIBER_ID}, ?USERNAME, ?PASSWORD, true]),
+                      [?PEER, {?MOUNTPOINT, ?NOT_ALLOWED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     {error, [next]} = vmq_plugin:all_till_ok(auth_on_register,
-                      [?PEER, {?MOUNTPOINT, ?IGNORED_SUBSCRIBER_ID}, ?USERNAME, ?PASSWORD, true]),
+                      [?PEER, {?MOUNTPOINT, ?IGNORED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     {ok, [{mountpoint, "mynewmount"}]} = vmq_plugin:all_till_ok(auth_on_register,
-                      [?PEER, {?MOUNTPOINT, ?CHANGED_SUBSCRIBER_ID}, ?USERNAME, ?PASSWORD, true]),
+                      [?PEER, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     deregister_hook(auth_on_register, ?ENDPOINT).
 
 auth_on_publish_test(_) ->
     register_hook(auth_on_publish, ?ENDPOINT),
     ok = vmq_plugin:all_till_ok(auth_on_publish,
-                      [?USERNAME, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+                      [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     {error, [error]} = vmq_plugin:all_till_ok(auth_on_publish,
-                      [?USERNAME, {?MOUNTPOINT, ?NOT_ALLOWED_SUBSCRIBER_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+                      [?USERNAME, {?MOUNTPOINT, ?NOT_ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     {error, [next]} = vmq_plugin:all_till_ok(auth_on_publish,
-                      [?USERNAME, {?MOUNTPOINT, ?IGNORED_SUBSCRIBER_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+                      [?USERNAME, {?MOUNTPOINT, ?IGNORED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     {ok, [{topic, [<<"rewritten">>, <<"topic">>]}]} = vmq_plugin:all_till_ok(auth_on_publish,
-                      [?USERNAME, {?MOUNTPOINT, ?CHANGED_SUBSCRIBER_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+                      [?USERNAME, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     deregister_hook(auth_on_publish, ?ENDPOINT).
 
 auth_on_subscribe_test(_) ->
     register_hook(auth_on_subscribe, ?ENDPOINT),
     ok = vmq_plugin:all_till_ok(auth_on_subscribe,
-                      [?USERNAME, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, [{?TOPIC, 1}]]),
+                      [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
     {error, [error]} = vmq_plugin:all_till_ok(auth_on_subscribe,
-                      [?USERNAME, {?MOUNTPOINT, ?NOT_ALLOWED_SUBSCRIBER_ID}, [{?TOPIC, 1}]]),
+                      [?USERNAME, {?MOUNTPOINT, ?NOT_ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
     {error, [next]} = vmq_plugin:all_till_ok(auth_on_subscribe,
-                      [?USERNAME, {?MOUNTPOINT, ?IGNORED_SUBSCRIBER_ID}, [{?TOPIC, 1}]]),
+                      [?USERNAME, {?MOUNTPOINT, ?IGNORED_CLIENT_ID}, [{?TOPIC, 1}]]),
     {ok, [{[<<"rewritten">>, <<"topic">>], 2}]} = vmq_plugin:all_till_ok(auth_on_subscribe,
-                      [?USERNAME, {?MOUNTPOINT, ?CHANGED_SUBSCRIBER_ID}, [{?TOPIC, 1}]]),
+                      [?USERNAME, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, [{?TOPIC, 1}]]),
     deregister_hook(auth_on_subscribe, ?ENDPOINT).
 
 on_register_test(_) ->
     register_hook(on_register, ?ENDPOINT),
     Self = pid_to_bin(self()),
     [next] = vmq_plugin:all(on_register,
-                            [?PEER, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, Self]),
+                            [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, Self]),
     ok = exp_response(on_register_ok),
     deregister_hook(on_register, ?ENDPOINT).
 
@@ -121,7 +121,7 @@ on_publish_test(_) ->
     register_hook(on_publish, ?ENDPOINT),
     Self = pid_to_bin(self()),
     [next] = vmq_plugin:all(on_publish,
-                           [Self, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+                           [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     ok = exp_response(on_publish_ok),
     deregister_hook(on_publish, ?ENDPOINT).
 
@@ -129,23 +129,23 @@ on_subscribe_test(_) ->
     register_hook(on_subscribe, ?ENDPOINT),
     Self = pid_to_bin(self()),
     [next] = vmq_plugin:all(on_subscribe,
-                            [Self, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, [{?TOPIC, 1}]]),
+                            [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [{?TOPIC, 1}]]),
     ok = exp_response(on_subscribe_ok),
     deregister_hook(on_subscribe, ?ENDPOINT).
 
 on_unsubscribe_test(_) ->
     register_hook(on_unsubscribe, ?ENDPOINT),
     ok = vmq_plugin:all_till_ok(on_unsubscribe,
-                                [?USERNAME, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, [?TOPIC]]),
+                                [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, [?TOPIC]]),
     {ok, [[<<"rewritten">>, <<"topic">>]]} = vmq_plugin:all_till_ok(on_unsubscribe,
-                      [?USERNAME, {?MOUNTPOINT, ?CHANGED_SUBSCRIBER_ID}, [?TOPIC]]),
+                      [?USERNAME, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, [?TOPIC]]),
     deregister_hook(on_unsubscribe, ?ENDPOINT).
 
 on_deliver_test(_) ->
     register_hook(on_deliver, ?ENDPOINT),
     Self = pid_to_bin(self()),
     ok = vmq_plugin:all_till_ok(on_deliver,
-                                [Self, {?MOUNTPOINT, ?ALLOWED_SUBSCRIBER_ID}, ?TOPIC, ?PAYLOAD]),
+                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?TOPIC, ?PAYLOAD]),
     ok = exp_response(on_deliver_ok),
     deregister_hook(on_deliver, ?ENDPOINT).
 
@@ -183,7 +183,7 @@ base64payload_test(_) ->
     {ok, [{payload, ?PAYLOAD}]} =
         vmq_plugin:all_till_ok(
           auth_on_publish,
-          [?USERNAME, {?MOUNTPOINT, ?BASE64_PAYLOAD_SUBSCRIBER_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+          [?USERNAME, {?MOUNTPOINT, ?BASE64_PAYLOAD_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     deregister_hook(auth_on_publish, ?ENDPOINT).
 
 %% helper functions

--- a/test/vmq_webhooks_SUITE.erl
+++ b/test/vmq_webhooks_SUITE.erl
@@ -152,7 +152,7 @@ on_deliver_test(_) ->
 on_offline_message_test(_) ->
     register_hook(on_offline_message, ?ENDPOINT),
     Self = pid_to_bin(self()),
-    [next] = vmq_plugin:all(on_offline_message, [{?MOUNTPOINT, Self}]),
+    [next] = vmq_plugin:all(on_offline_message, [{?MOUNTPOINT, Self}, 1, ?TOPIC, ?PAYLOAD, false]),
     ok = exp_response(on_offline_message_ok),
     deregister_hook(on_offline_message, ?ENDPOINT).
 

--- a/test/vmq_webhooks_SUITE.erl
+++ b/test/vmq_webhooks_SUITE.erl
@@ -179,7 +179,7 @@ on_client_gone_test(_) ->
 
 base64payload_test(_) ->
     ok = clique:run(["vmq-admin", "webhooks", "register",
-                     "hook=auth_on_publish", "endpoint=" ++ ?ENDPOINT, "--encodepayload=true"]),
+                     "hook=auth_on_publish", "endpoint=" ++ ?ENDPOINT, "--base64payload=true"]),
     {ok, [{payload, ?PAYLOAD}]} =
         vmq_plugin:all_till_ok(
           auth_on_publish,
@@ -189,7 +189,7 @@ base64payload_test(_) ->
 %% helper functions
 register_hook(Hook, Endpoint) ->
     ok = clique:run(["vmq-admin", "webhooks", "register",
-                     "hook=" ++ atom_to_list(Hook), "endpoint=" ++ Endpoint, "--encodepayload=false"]).
+                     "hook=" ++ atom_to_list(Hook), "endpoint=" ++ Endpoint, "--base64payload=false"]).
 
 deregister_hook(Hook, Endpoint) ->
     ok = clique:run(["vmq-admin", "webhooks", "deregister",

--- a/test/vmq_webhooks_test.hrl
+++ b/test/vmq_webhooks_test.hrl
@@ -3,14 +3,14 @@
 -define(PEER_BIN, <<"127.0.0.1">>).
 -define(PEERPORT, 12345).
 -define(PEER, {{127,0,0,1}, ?PEERPORT}).
--define(IGNORED_SUBSCRIBER_ID, <<"ignored-subscriber-id">>).
--define(ALLOWED_SUBSCRIBER_ID, <<"allowed-subscriber-id">>).
--define(BASE64_PAYLOAD_SUBSCRIBER_ID, <<"payload-is-base64-encoded">>).
--define(NOT_ALLOWED_SUBSCRIBER_ID, <<"not-allowed-subscriber-id">>).
+-define(IGNORED_CLIENT_ID, <<"ignored-subscriber-id">>).
+-define(ALLOWED_CLIENT_ID, <<"allowed-subscriber-id">>).
+-define(BASE64_PAYLOAD_CLIENT_ID, <<"payload-is-base64-encoded">>).
+-define(NOT_ALLOWED_CLIENT_ID, <<"not-allowed-subscriber-id">>).
 -define(SERVER_ERR_SUBSCIBER_ID, <<"internal-server-error">>).
 -define(MOUNTPOINT, "mountpoint").
 -define(MOUNTPOINT_BIN, <<"mountpoint">>).
--define(CHANGED_SUBSCRIBER_ID, <<"changed-subscriber-id">>).
+-define(CHANGED_CLIENT_ID, <<"changed-subscriber-id">>).
 -define(USERNAME, <<"test-user">>).
 -define(PASSWORD, <<"test-password">>).
 -define(TOPIC, <<"test/topic">>).

--- a/test/vmq_webhooks_test.hrl
+++ b/test/vmq_webhooks_test.hrl
@@ -5,6 +5,7 @@
 -define(PEER, {{127,0,0,1}, ?PEERPORT}).
 -define(IGNORED_SUBSCRIBER_ID, <<"ignored-subscriber-id">>).
 -define(ALLOWED_SUBSCRIBER_ID, <<"allowed-subscriber-id">>).
+-define(BASE64_PAYLOAD_SUBSCRIBER_ID, <<"payload-is-base64-encoded">>).
 -define(NOT_ALLOWED_SUBSCRIBER_ID, <<"not-allowed-subscriber-id">>).
 -define(SERVER_ERR_SUBSCIBER_ID, <<"internal-server-error">>).
 -define(MOUNTPOINT, "mountpoint").

--- a/test/webhooks_handler.erl
+++ b/test/webhooks_handler.erl
@@ -36,25 +36,25 @@ handle(Req, State) ->
 %% callbacks for each hook
 auth_on_register(#{peer_addr := ?PEER_BIN,
                    peer_port := ?PEERPORT,
-                   subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+                   client_id := ?ALLOWED_CLIENT_ID,
                    mountpoint := ?MOUNTPOINT_BIN,
                    username := ?USERNAME,
                    password := ?PASSWORD,
                    clean_session := true
                  }) ->
     {200, #{result => <<"ok">>}};
-auth_on_register(#{subscriber_id := ?NOT_ALLOWED_SUBSCRIBER_ID}) ->
+auth_on_register(#{client_id := ?NOT_ALLOWED_CLIENT_ID}) ->
     {200, #{result => #{error => <<"not_allowed">>}}};
-auth_on_register(#{subscriber_id := ?IGNORED_SUBSCRIBER_ID}) ->
+auth_on_register(#{client_id := ?IGNORED_CLIENT_ID}) ->
     {200, #{result => <<"next">>}};
-auth_on_register(#{subscriber_id := ?CHANGED_SUBSCRIBER_ID}) ->
+auth_on_register(#{client_id := ?CHANGED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             modifiers => #{mountpoint => <<"mynewmount">>}}};
 auth_on_register(#{subscriberid := <<"internal_server_error">>}) ->
     throw(internal_server_error).
 
 auth_on_publish(#{username := ?USERNAME,
-                  subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+                  client_id := ?ALLOWED_CLIENT_ID,
                   mountpoint := ?MOUNTPOINT_BIN,
                   qos := 1,
                   topic := ?TOPIC,
@@ -63,7 +63,7 @@ auth_on_publish(#{username := ?USERNAME,
                  }) ->
     {200, #{result => <<"ok">>}};
 auth_on_publish(#{username := ?USERNAME,
-                  subscriber_id := ?BASE64_PAYLOAD_SUBSCRIBER_ID,
+                  client_id := ?BASE64_PAYLOAD_CLIENT_ID,
                   mountpoint := ?MOUNTPOINT_BIN,
                   qos := 1,
                   topic := ?TOPIC,
@@ -73,27 +73,27 @@ auth_on_publish(#{username := ?USERNAME,
     ?PAYLOAD = base64:decode(Base64Payload),
     {200, #{result => <<"ok">>,
             modifiers => #{payload => base64:encode(?PAYLOAD)}}};
-auth_on_publish(#{subscriber_id := ?NOT_ALLOWED_SUBSCRIBER_ID}) ->
+auth_on_publish(#{client_id := ?NOT_ALLOWED_CLIENT_ID}) ->
     {200, #{result => #{error => <<"not_allowed">>}}};
-auth_on_publish(#{subscriber_id := ?IGNORED_SUBSCRIBER_ID}) ->
+auth_on_publish(#{client_id := ?IGNORED_CLIENT_ID}) ->
     {200, #{result => <<"next">>}};
-auth_on_publish(#{subscriber_id := ?CHANGED_SUBSCRIBER_ID}) ->
+auth_on_publish(#{client_id := ?CHANGED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             modifiers => #{topic => <<"rewritten/topic">>}}};
 auth_on_publish(#{subscriberid := <<"internal_server_error">>}) ->
     throw(internal_server_error).
 
 auth_on_subscribe(#{username := ?USERNAME,
-                    subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+                    client_id := ?ALLOWED_CLIENT_ID,
                     mountpoint := ?MOUNTPOINT_BIN,
                     topics := [#{topic := ?TOPIC, qos := 1}]
                  }) ->
     {200, #{result => <<"ok">>}};
-auth_on_subscribe(#{subscriber_id := ?NOT_ALLOWED_SUBSCRIBER_ID}) ->
+auth_on_subscribe(#{client_id := ?NOT_ALLOWED_CLIENT_ID}) ->
     {200, #{result => #{error => <<"not_allowed">>}}};
-auth_on_subscribe(#{subscriber_id := ?IGNORED_SUBSCRIBER_ID}) ->
+auth_on_subscribe(#{client_id := ?IGNORED_CLIENT_ID}) ->
     {200, #{result => <<"next">>}};
-auth_on_subscribe(#{subscriber_id := ?CHANGED_SUBSCRIBER_ID}) ->
+auth_on_subscribe(#{client_id := ?CHANGED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             topics =>
                 [#{topic => <<"rewritten/topic">>,
@@ -104,7 +104,7 @@ auth_on_subscribe(#{subscriberid := <<"internal_server_error">>}) ->
 on_register(#{peer_addr := ?PEER_BIN,
               peer_port := ?PEERPORT,
               mountpoint := ?MOUNTPOINT_BIN,
-              subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+              client_id := ?ALLOWED_CLIENT_ID,
               username := BinPid}) -> 
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_register_ok,
@@ -112,7 +112,7 @@ on_register(#{peer_addr := ?PEER_BIN,
 
 on_publish(#{username := BinPid,
              mountpoint := ?MOUNTPOINT_BIN,
-             subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+             client_id := ?ALLOWED_CLIENT_ID,
              topic := ?TOPIC,
              qos := 1,
              payload := ?PAYLOAD,
@@ -123,22 +123,22 @@ on_publish(#{username := BinPid,
 
 on_subscribe(#{username := BinPid,
                mountpoint := ?MOUNTPOINT_BIN,
-               subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+               client_id := ?ALLOWED_CLIENT_ID,
                topics := [#{topic := ?TOPIC, qos := 1}]
               }) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_subscribe_ok,
     {200, #{}}.
 
-on_unsubscribe(#{subscriber_id := ?ALLOWED_SUBSCRIBER_ID}) ->
+on_unsubscribe(#{client_id := ?ALLOWED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>}};
-on_unsubscribe(#{subscriber_id := ?CHANGED_SUBSCRIBER_ID}) ->
+on_unsubscribe(#{client_id := ?CHANGED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             topics => [<<"rewritten/topic">>]}}.
 
 on_deliver(#{username := BinPid,
              mountpoint := ?MOUNTPOINT_BIN,
-             subscriber_id := ?ALLOWED_SUBSCRIBER_ID,
+             client_id := ?ALLOWED_CLIENT_ID,
              topic := ?TOPIC,
              payload := ?PAYLOAD}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
@@ -146,25 +146,25 @@ on_deliver(#{username := BinPid,
     {200, #{result => <<"ok">>}}.
 
 on_offline_message(#{mountpoint := ?MOUNTPOINT_BIN,
-                     subscriber_id := BinPid}) ->
+                     client_id := BinPid}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_offline_message_ok,
     {200, #{}}.
 
 on_client_wakeup(#{mountpoint := ?MOUNTPOINT_BIN,
-                   subscriber_id := BinPid}) ->
+                   client_id := BinPid}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_client_wakeup_ok,
     {200, #{}}.
 
 on_client_offline(#{mountpoint := ?MOUNTPOINT_BIN,
-                   subscriber_id := BinPid}) ->
+                   client_id := BinPid}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_client_offline_ok,
     {200, #{}}.
 
 on_client_gone(#{mountpoint := ?MOUNTPOINT_BIN,
-                 subscriber_id := BinPid}) ->
+                 client_id := BinPid}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_client_gone_ok,
     {200, #{}}.

--- a/test/webhooks_handler.erl
+++ b/test/webhooks_handler.erl
@@ -62,6 +62,17 @@ auth_on_publish(#{username := ?USERNAME,
                   retain := false
                  }) ->
     {200, #{result => <<"ok">>}};
+auth_on_publish(#{username := ?USERNAME,
+                  subscriber_id := ?BASE64_PAYLOAD_SUBSCRIBER_ID,
+                  mountpoint := ?MOUNTPOINT_BIN,
+                  qos := 1,
+                  topic := ?TOPIC,
+                  payload := Base64Payload,
+                  retain := false
+                 }) ->
+    ?PAYLOAD = base64:decode(Base64Payload),
+    {200, #{result => <<"ok">>,
+            modifiers => #{payload => base64:encode(?PAYLOAD)}}};
 auth_on_publish(#{subscriber_id := ?NOT_ALLOWED_SUBSCRIBER_ID}) ->
     {200, #{result => #{error => <<"not_allowed">>}}};
 auth_on_publish(#{subscriber_id := ?IGNORED_SUBSCRIBER_ID}) ->


### PR DESCRIPTION
hey @dergraf can you take a look at this at some point?

The idea here is to, by default, base64 encode payloads for all endpoints. Using `--encodepayload=false` this behaviour can be disabled when registering an endpoint.

This fixes #5 

Also in this PR is an update for the `on_offline_message` hook and code to load webhooks from a file.